### PR TITLE
Check for null in where clauses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -610,6 +610,7 @@ class Update<
       const setSql = dynamicSetClauses.join(', ');
       let query = `UPDATE ${this.table} SET ${setSql}${whereClause}${limitClause} RETURNING *`;
       query = updateQueryWithIsNull(query, whereVals, whereNames);
+      console.log(query);
       const result = await db.query(query, vals);
       if (this.isSingular) {
         return result.rowCount === 0 ? null : result.rows[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,39 @@ type Join<TableSchemaT, Joins> = {
 
 type Result<T, IsSingular> = IsSingular extends true ? T | null : T[];
 
+// In the case that the user is trying to match against a NULL value, we
+// need to replace "col = $1" with "col IS NULL". We keep the "col = $1"
+// clause, even though it can never match, to avoid having to renumber.
+function updateQueryWithIsNull(
+  query: string,
+  whereValues: any[],
+  whereNames: string[],
+): string {
+  let thisQuery = query;
+  whereValues.forEach((value, i) => {
+    if (value === null || (Array.isArray(value) && value.includes(null))) {
+      const name = whereNames[i];
+      let pat = `${name} = $`;
+      let idx = thisQuery.indexOf(pat);
+      if (idx === -1) {
+        pat = `${name} = ANY($`;
+        idx = thisQuery.indexOf(pat);
+      }
+      if (idx >= 0) {
+        const pre = thisQuery.slice(0, idx);
+        const post = thisQuery.slice(idx + pat.length);
+        const m = /^(\d+)(.*)/.exec(post);
+        if (!m) {
+          throw new Error('Unable to match null in ' + query);
+        }
+        const [, dig, rest] = m;
+        thisQuery = `${pre}(${name} IS NULL OR ${pat}${dig})${rest}`;
+      }
+    }
+  });
+  return thisQuery;
+}
+
 class Select<
   TableSchemaT,
   TableT,
@@ -336,32 +369,7 @@ class Select<
           ? Array.from(whereObj[col])
           : whereObj[col],
       );
-
-      // In the case that the user is trying to match against a NULL value, we
-      // need to replace "col = $1" with "col IS NULL". We keep the "col = $1"
-      // clause, even though it can never match, to avoid having to renumber.
-      let thisQuery = query;
-      where.forEach((value, i) => {
-        if (value === null || (Array.isArray(value) && value.includes(null))) {
-          const name = whereNames[i];
-          let pat = `${name} = $`;
-          let idx = thisQuery.indexOf(pat);
-          if (idx === -1) {
-            pat = `${name} = ANY($`;
-            idx = thisQuery.indexOf(pat);
-          }
-          if (idx >= 0) {
-            const pre = thisQuery.slice(0, idx);
-            const post = thisQuery.slice(idx + pat.length);
-            const m = /^(\d+)(.*)/.exec(post);
-            if (!m) {
-              throw new Error('Unable to match null in ' + query);
-            }
-            const [, dig, rest] = m;
-            thisQuery = `${pre}(${name} IS NULL OR ${pat}${dig})${rest}`;
-          }
-        }
-      });
+      const thisQuery = updateQueryWithIsNull(query, where, whereNames);
 
       const result = await db.query(thisQuery, where);
       if (this.isSingular) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,11 +643,13 @@ class Delete<TableT, WhereCols = null, WhereAnyCols = never, LimitOne = false> {
 
     const whereKeys: string[] = [];
     const whereClauses: string[] = [];
+    const whereNames: string[] = [];
     if (this.whereCols) {
       for (const col of this.whereCols as unknown as string[]) {
         whereKeys.push(col);
         const n = placeholder++;
         whereClauses.push(`${col} = $${n}`);
+        whereNames.push(col);
       }
     }
     if (this.whereAnyCols) {
@@ -656,6 +658,7 @@ class Delete<TableT, WhereCols = null, WhereAnyCols = never, LimitOne = false> {
         whereKeys.push(col);
         const n = placeholder++;
         whereClauses.push(`${col} = ANY($${n})`);
+        whereNames.push(col);
       }
     }
     const whereClause = whereClauses.length
@@ -672,7 +675,8 @@ class Delete<TableT, WhereCols = null, WhereAnyCols = never, LimitOne = false> {
           ? Array.from(whereObj[col])
           : whereObj[col],
       );
-      const result = await db.query(query, vals);
+      const thisQuery = updateQueryWithIsNull(query, vals, whereNames);
+      const result = await db.query(thisQuery, vals);
       if (this.isSingular) {
         return result.rowCount === 0 ? null : result.rows[0];
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,14 +241,15 @@ function updateQueryWithIsNull(
   whereNames: string[],
 ): string {
   let thisQuery = query;
+  const whereIdx = query.indexOf('WHERE'); // only tweak WHERE clause, not SET clause for UPDATE.
   whereValues.forEach((value, i) => {
     if (value === null || (Array.isArray(value) && value.includes(null))) {
       const name = whereNames[i];
       let pat = `${name} = $`;
-      let idx = thisQuery.indexOf(pat);
+      let idx = thisQuery.indexOf(pat, whereIdx);
       if (idx === -1) {
         pat = `${name} = ANY($`;
-        idx = thisQuery.indexOf(pat);
+        idx = thisQuery.indexOf(pat, whereIdx);
       }
       if (idx >= 0) {
         const pre = thisQuery.slice(0, idx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,7 @@ class Select<
           }
         }
       });
+
       const result = await db.query(thisQuery, where);
       if (this.isSingular) {
         if (result.rowCount === 0) {

--- a/test/e2e/delete-e2e.test.ts
+++ b/test/e2e/delete-e2e.test.ts
@@ -6,7 +6,7 @@ const typedDb = new TypedSQL(tables);
 
 // const userTable = typedDb.table('users');
 const commentsTable = typedDb.table('comment');
-// const docTable = typedDb.table('doc');
+const docTable = typedDb.table('doc');
 
 const COMMENT1_ID = '01234567-1f62-4f80-ad29-3ad48a03a36e';
 const COMMENT2_ID = '12345678-1f62-4f80-ad29-3ad48a03a36e';
@@ -35,6 +35,22 @@ describe('delete e2e', () => {
     const finalComments = await getAllComments(db);
     expect(finalComments).toHaveLength(1);
     expect(finalComments).toMatchObject([{id: COMMENT2_ID}]);
+  });
+
+  it('should delete rows with a null value', async () => {
+    const deleteByContents = docTable.delete({where: ['contents']});
+    const deleted = await deleteByContents(db, {contents: null});
+    expect(deleted).toHaveLength(1);
+    expect(deleted).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "contents": null,
+          "created_by": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+          "id": "98765432-1f62-4f80-ad29-3ad48a03a36e",
+          "title": "Blank Slate",
+        },
+      ]
+    `);
   });
 
   describe('delete multiple', () => {

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -300,6 +300,17 @@ describe('select e2e ', () => {
             "id": "01234b31-1f62-4f80-ad29-3ad48a03a36e",
             "title": "Vision 2023",
           },
+          Object {
+            "author": Object {
+              "id": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+              "name": "John Deere",
+              "pronoun": "he/him",
+            },
+            "contents": null,
+            "created_by": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+            "id": "98765432-1f62-4f80-ad29-3ad48a03a36e",
+            "title": "Blank Slate",
+          },
         ]
       `);
     });

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -140,6 +140,12 @@ describe('select e2e ', () => {
     ).toMatchInlineSnapshot(`Array []`);
   });
 
+  it.only('should select by a column with a null value', async () => {
+    const selectDocByContent = docTable.select({where: ['contents']});
+    const nullDocs = await selectDocByContent(db, {contents: null});
+    expect(nullDocs).toHaveLength(1);
+  });
+
   it('should allow selecting by a set of possible values', async () => {
     const selectAnyOf = usersTable.select({where: [any('id')]});
 

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -140,10 +140,18 @@ describe('select e2e ', () => {
     ).toMatchInlineSnapshot(`Array []`);
   });
 
-  it.only('should select by a column with a null value', async () => {
+  it('should select by a column with a null value', async () => {
     const selectDocByContent = docTable.select({where: ['contents']});
     const nullDocs = await selectDocByContent(db, {contents: null});
     expect(nullDocs).toHaveLength(1);
+    expect(db.q).toMatchInlineSnapshot(
+      `"SELECT * FROM doc WHERE (contents IS NULL OR contents = $1)"`,
+    );
+    expect(db.args).toMatchInlineSnapshot(`
+      Array [
+        null,
+      ]
+    `);
   });
 
   it('should allow selecting by a set of possible values', async () => {

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -510,5 +510,40 @@ describe('select e2e ', () => {
         }
       `);
     });
+
+    it('should join with a null where clause', async () => {
+      const select = docTable.select({
+        where: ['contents', 'title'],
+        join: {author: 'created_by'},
+      });
+      const nullDocsWithAuthor = await select(db, {
+        contents: null,
+        title: 'Blank Slate',
+      });
+      expect(nullDocsWithAuthor).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "author": Object {
+              "id": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+              "name": "John Deere",
+              "pronoun": "he/him",
+            },
+            "contents": null,
+            "created_by": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+            "id": "98765432-1f62-4f80-ad29-3ad48a03a36e",
+            "title": "Blank Slate",
+          },
+        ]
+      `);
+      expect(db.q).toMatchInlineSnapshot(
+        `"SELECT t1.*, to_jsonb(t2.*) as author FROM doc as t1 JOIN users AS t2 ON t1.created_by = t2.id WHERE (t1.contents IS NULL OR t1.contents = $1) AND t1.title = $2"`,
+      );
+      expect(db.args).toMatchInlineSnapshot(`
+        Array [
+          null,
+          "Blank Slate",
+        ]
+      `);
+    });
   });
 });

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -193,6 +193,22 @@ describe('select e2e ', () => {
     expect(usersArray).toEqual(users1);
   });
 
+  it.only('should select by a set of values that includes null', async () => {
+    const selectAnyDoc = docTable.select({where: [any('contents')]});
+    const nullDocs = await selectAnyDoc(db, {contents: [null]});
+    expect(nullDocs).toMatchInlineSnapshot(`Array []`);
+    expect(db.q).toMatchInlineSnapshot(
+      `"SELECT * FROM doc WHERE contents = ANY($1)"`,
+    );
+    expect(db.args).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          null,
+        ],
+      ]
+    `);
+  });
+
   it('should select by primary key', async () => {
     const selectById = typedDb.table('users').selectByPrimaryKey();
     const userDoe = await selectById(db, {

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -263,6 +263,24 @@ describe('select e2e ', () => {
     `);
   });
 
+  it('should select by a mix of null and non-null values', async () => {
+    const selectDocByContent = docTable.select({where: ['contents', 'title']});
+    const nullDocs = await selectDocByContent(db, {
+      contents: null,
+      title: 'Blank Slate',
+    });
+    expect(nullDocs).toHaveLength(1);
+    expect(db.q).toMatchInlineSnapshot(
+      `"SELECT * FROM doc WHERE (contents IS NULL OR contents = $1) AND title = $2"`,
+    );
+    expect(db.args).toMatchInlineSnapshot(`
+      Array [
+        null,
+        "Blank Slate",
+      ]
+    `);
+  });
+
   it('should allow multiple plural where clauses', async () => {
     const select = commentsTable.select({
       where: [any('author_id'), any('doc_id')],

--- a/test/e2e/select.test.ts
+++ b/test/e2e/select.test.ts
@@ -193,12 +193,22 @@ describe('select e2e ', () => {
     expect(usersArray).toEqual(users1);
   });
 
-  it.only('should select by a set of values that includes null', async () => {
+  it('should select by a set of values that includes null', async () => {
     const selectAnyDoc = docTable.select({where: [any('contents')]});
     const nullDocs = await selectAnyDoc(db, {contents: [null]});
-    expect(nullDocs).toMatchInlineSnapshot(`Array []`);
+    expect(nullDocs).toHaveLength(1);
+    expect(nullDocs).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "contents": null,
+          "created_by": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+          "id": "98765432-1f62-4f80-ad29-3ad48a03a36e",
+          "title": "Blank Slate",
+        },
+      ]
+    `);
     expect(db.q).toMatchInlineSnapshot(
-      `"SELECT * FROM doc WHERE contents = ANY($1)"`,
+      `"SELECT * FROM doc WHERE (contents IS NULL OR contents = ANY($1))"`,
     );
     expect(db.args).toMatchInlineSnapshot(`
       Array [

--- a/test/e2e/update-e2e.test.ts
+++ b/test/e2e/update-e2e.test.ts
@@ -113,6 +113,10 @@ describe('update e2e', () => {
     `);
     expect(await docTable.select()(db)).toMatchObject([
       {
+        title: 'Blank Slate',
+        contents: null,
+      },
+      {
         title: 'Annual Plan for 2022',
         contents: 'Looking gloomy',
       },
@@ -189,10 +193,12 @@ describe('update e2e', () => {
     expect(await update(db, {}, {contents: 'This and that'})).toMatchObject([
       {title: 'Annual Plan for 2022', contents: 'This and that'},
       {title: 'Vision 2023', contents: 'This and that'},
+      {title: 'Blank Slate', contents: 'This and that'},
     ]);
     expect(await getAllDocs(db)).toMatchObject([
       {title: 'Annual Plan for 2022', contents: 'This and that'},
       {title: 'Vision 2023', contents: 'This and that'},
+      {title: 'Blank Slate', contents: 'This and that'},
     ]);
   });
 
@@ -214,6 +220,7 @@ describe('update e2e', () => {
     ]);
 
     expect(await getAllDocs(db)).toMatchObject([
+      {title: 'Blank Slate', contents: null},
       {title: 'Annual Plan for 2022', contents: 'To Be Written'},
       {title: 'Vision 2023', contents: 'To Be Written'},
     ]);
@@ -237,6 +244,7 @@ describe('update e2e', () => {
     ]);
 
     expect(await getAllDocs(db)).toMatchObject([
+      {title: 'Blank Slate', contents: null},
       {title: 'Annual Plan for 2022', contents: 'To Be Written'},
       {title: 'Vision 2023', contents: 'To Be Written'},
     ]);

--- a/test/e2e/update-e2e.test.ts
+++ b/test/e2e/update-e2e.test.ts
@@ -127,6 +127,20 @@ describe('update e2e', () => {
     ]);
   });
 
+  it.only('should update with a where null clause', async () => {
+    const updateDocByContents = docTable.update({where: ['contents']});
+    const filledOutDocs = await updateDocByContents(
+      db,
+      {contents: null},
+      {contents: 'to be written'},
+    );
+    expect(filledOutDocs).toMatchInlineSnapshot();
+
+    const doc = await getDocByTitle(db, {title: 'Blank Slate'});
+    expect(doc).toHaveLength(1);
+    expect(doc[0].contents).toEqual('to be written');
+  });
+
   it('should update with fixed columns', async () => {
     const update = docTable.update({set: ['contents'], where: ['title']});
     expect(

--- a/test/e2e/update-e2e.test.ts
+++ b/test/e2e/update-e2e.test.ts
@@ -127,14 +127,23 @@ describe('update e2e', () => {
     ]);
   });
 
-  it.only('should update with a where null clause', async () => {
+  it('should update with a where null clause', async () => {
     const updateDocByContents = docTable.update({where: ['contents']});
     const filledOutDocs = await updateDocByContents(
       db,
       {contents: null},
       {contents: 'to be written'},
     );
-    expect(filledOutDocs).toMatchInlineSnapshot();
+    expect(filledOutDocs).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "contents": "to be written",
+          "created_by": "dee5e220-1f62-4f80-ad29-3ad48a03a36e",
+          "id": "98765432-1f62-4f80-ad29-3ad48a03a36e",
+          "title": "Blank Slate",
+        },
+      ]
+    `);
 
     const doc = await getDocByTitle(db, {title: 'Blank Slate'});
     expect(doc).toHaveLength(1);

--- a/test/sql/testdata.sql
+++ b/test/sql/testdata.sql
@@ -21,6 +21,12 @@ INSERT INTO doc(id, created_by, title, contents) VALUES (
     'd0e23a20-1f62-4f80-ad29-3ad48a03a47f', -- Jane Doe
     'Vision 2023',
     'Future so bright'
+),
+(
+    '98765432-1f62-4f80-ad29-3ad48a03a36e',
+    'dee5e220-1f62-4f80-ad29-3ad48a03a36e', -- John Deere,
+    'Blank Slate',
+    null
 );
 
 INSERT INTO COMMENT(id, doc_id, author_id, created_at, modified_at, metadata, content_md, statuses) VALUES (

--- a/test/unit/delete-unit.test.ts
+++ b/test/unit/delete-unit.test.ts
@@ -50,7 +50,7 @@ describe('delete unit', () => {
     const deleteByTitle = docTable.delete({where: ['title']});
     await deleteByTitle(mockDb, {title: null});
     expect(mockDb.q).toMatchInlineSnapshot(
-      `"DELETE FROM doc WHERE title = $1 RETURNING *"`,
+      `"DELETE FROM doc WHERE (title IS NULL OR title = $1) RETURNING *"`,
     );
     expect(mockDb.args).toMatchInlineSnapshot(`
       Array [

--- a/test/unit/delete-unit.test.ts
+++ b/test/unit/delete-unit.test.ts
@@ -6,7 +6,7 @@ const typedDb = new TypedSQL(tables);
 
 const userTable = typedDb.table('users');
 // const commentsTable = typedDb.table('comment');
-// const docTable = typedDb.table('doc');
+const docTable = typedDb.table('doc');
 
 describe('delete unit', () => {
   it('should delete all entries', async () => {
@@ -42,6 +42,29 @@ describe('delete unit', () => {
           "id1",
           "id2",
         ],
+      ]
+    `);
+  });
+
+  it('should delete entries with null values', async () => {
+    const deleteByTitle = docTable.delete({where: ['title']});
+    await deleteByTitle(mockDb, {title: null});
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"DELETE FROM doc WHERE title = $1 RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        null,
+      ]
+    `);
+
+    await deleteByTitle(mockDb, {title: 'not-null'});
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"DELETE FROM doc WHERE title = $1 RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        "not-null",
       ]
     `);
   });

--- a/test/unit/update-unit.test.ts
+++ b/test/unit/update-unit.test.ts
@@ -99,10 +99,26 @@ describe('update', () => {
     await update(mockDb, {title: null}, {title: 'Unknown'});
 
     expect(mockDb.q).toMatchInlineSnapshot(
-      `"UPDATE doc SET (title IS NULL OR title = $2) WHERE title = $1 RETURNING *"`,
+      `"UPDATE doc SET title = $2 WHERE (title IS NULL OR title = $1) RETURNING *"`,
     );
     expect(mockDb.args).toMatchInlineSnapshot(`
       Array [
+        null,
+        "Unknown",
+      ]
+    `);
+  });
+
+  it('should update two null columns', async () => {
+    const update = docTable.update({where: ['title', 'contents']});
+    await update(mockDb, {title: null, contents: null}, {title: 'Unknown'});
+
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"UPDATE doc SET title = $3 WHERE (title IS NULL OR title = $1) AND (contents IS NULL OR contents = $2) RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        null,
         null,
         "Unknown",
       ]

--- a/test/unit/update-unit.test.ts
+++ b/test/unit/update-unit.test.ts
@@ -79,6 +79,21 @@ describe('update', () => {
     expect(mockDb.args).toEqual(arrayArgs);
   });
 
+  it.only('should update with a where null clause', async () => {
+    const update = docTable.update({where: ['title']});
+    await update(mockDb, {title: null}, {created_by: 'Unknown'});
+
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"UPDATE doc SET created_by = $2 WHERE title = $1 RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        null,
+        "Unknown",
+      ]
+    `);
+  });
+
   it('should update with fixed columns', async () => {
     const update = docTable.update({set: ['contents'], where: ['title']});
     await update(

--- a/test/unit/update-unit.test.ts
+++ b/test/unit/update-unit.test.ts
@@ -113,6 +113,21 @@ describe('update', () => {
     `);
   });
 
+  it('should update with fixed columns and a where null clause', async () => {
+    const update = docTable.update({set: ['created_by'], where: ['title']});
+    await update(mockDb, {title: null}, {created_by: 'Unknown'});
+
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"UPDATE doc SET created_by = $1 WHERE (title IS NULL OR title = $2) RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        "Unknown",
+        null,
+      ]
+    `);
+  });
+
   it('should update with fixed columns and limitOne', async () => {
     const update = docTable.update({
       set: ['contents'],

--- a/test/unit/update-unit.test.ts
+++ b/test/unit/update-unit.test.ts
@@ -79,12 +79,12 @@ describe('update', () => {
     expect(mockDb.args).toEqual(arrayArgs);
   });
 
-  it.only('should update with a where null clause', async () => {
+  it('should update with a where null clause', async () => {
     const update = docTable.update({where: ['title']});
     await update(mockDb, {title: null}, {created_by: 'Unknown'});
 
     expect(mockDb.q).toMatchInlineSnapshot(
-      `"UPDATE doc SET created_by = $2 WHERE title = $1 RETURNING *"`,
+      `"UPDATE doc SET created_by = $2 WHERE (title IS NULL OR title = $1) RETURNING *"`,
     );
     expect(mockDb.args).toMatchInlineSnapshot(`
       Array [

--- a/test/unit/update-unit.test.ts
+++ b/test/unit/update-unit.test.ts
@@ -94,6 +94,21 @@ describe('update', () => {
     `);
   });
 
+  it('should update a null column', async () => {
+    const update = docTable.update({where: ['title']});
+    await update(mockDb, {title: null}, {title: 'Unknown'});
+
+    expect(mockDb.q).toMatchInlineSnapshot(
+      `"UPDATE doc SET (title IS NULL OR title = $2) WHERE title = $1 RETURNING *"`,
+    );
+    expect(mockDb.args).toMatchInlineSnapshot(`
+      Array [
+        null,
+        "Unknown",
+      ]
+    `);
+  });
+
   it('should update with fixed columns', async () => {
     const update = docTable.update({set: ['contents'], where: ['title']});
     await update(


### PR DESCRIPTION
If the `where` clause of a query contains a `null` value, or is a set containing a `null` value, then we replace:

- `WHERE column = $1` → `WHERE (column IS NULL OR column = $1)`
- `WHERE column = ANY($1)` → `WHERE (column IS NULL OR column = ANY($1))`

Especially in the former case this is a little roundabout since the `column = $1` clause can never match. But this does have the advantage that we don't need to renumber all the remaining fields.

Fixes #22 